### PR TITLE
Update links to github with the new repo name - score-actions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,11 +9,11 @@
         http://www.apache.org/licenses/LICENSE-2.0
     -->
 	<groupId>io.openscore.content</groupId>
-	<artifactId>score-content</artifactId>
+	<artifactId>score-actions</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
     <description>Precompiled flows for score</description>
-    <url>https://github.com/openscore/score-content</url>
+    <url>https://github.com/openscore/score-actions</url>
     <licenses>
       <license>
         <name>The Apache License, Version 2.0</name>
@@ -41,9 +41,9 @@
       </developer>
     </developers>
 	<scm>
-		<connection>scm:git:https://openscore/score-content.git</connection>
-		<developerConnection>scm:git:git@github.com:openscore/score-content.git</developerConnection>
-		<url>https://github.com/openscore/score-content.git</url>
+		<connection>scm:git:https://openscore/score-actions.git</connection>
+		<developerConnection>scm:git:git@github.com:openscore/score-actions.git</developerConnection>
+		<url>https://github.com/openscore/score-actions.git</url>
 		<tag>master</tag>
 	</scm>
     <distributionManagement>

--- a/score-http-client/pom.xml
+++ b/score-http-client/pom.xml
@@ -13,7 +13,7 @@
     <version>0.1.45-SNAPSHOT</version>
     <packaging>jar</packaging>
     <description>An HTTP client for score</description>
-    <url>https://github.com/openscore/score-content</url>
+    <url>https://github.com/openscore/score-actions</url>
     <name>org.openscore.content:score-http-client</name>
     <licenses>
       <license>
@@ -42,9 +42,9 @@
       </developer>
     </developers>
     <scm>
-        <connection>scm:git:https://openscore/score-content.git</connection>
-        <developerConnection>scm:git:git@github.com:openscore/score-content.git</developerConnection>
-        <url>https://github.com/openscore/score-content.git</url>
+        <connection>scm:git:https://openscore/score-actions.git</connection>
+        <developerConnection>scm:git:git@github.com:openscore/score-actions.git</developerConnection>
+        <url>https://github.com/openscore/score-actions.git</url>
         <tag>master</tag>
     </scm>
     <distributionManagement>

--- a/score-mail/pom.xml
+++ b/score-mail/pom.xml
@@ -17,7 +17,7 @@
 
     <name>org.openscore.content:score-mail</name>
     <description>Mail java actions</description>
-    <url>https://github.com/openscore/score-content</url>
+    <url>https://github.com/openscore/score-actions</url>
 
     <licenses>
         <license>
@@ -48,9 +48,9 @@
     </developers>
 
     <scm>
-        <connection>scm:git:https://openscore/score-content.git</connection>
-        <developerConnection>scm:git:git@github.com:openscore/score-content.git</developerConnection>
-        <url>https://github.com/openscore/score-content.git</url>
+        <connection>scm:git:https://openscore/score-actions.git</connection>
+        <developerConnection>scm:git:git@github.com:openscore/score-actions.git</developerConnection>
+        <url>https://github.com/openscore/score-actions.git</url>
         <tag>master</tag>
     </scm>
     <distributionManagement>

--- a/score-ssh/pom.xml
+++ b/score-ssh/pom.xml
@@ -16,7 +16,7 @@
     <packaging>jar</packaging>
     <name>org.openscore.content:score-ssh</name>
     <description>SSH java actions</description>
-    <url>https://github.com/openscore/score-content</url>
+    <url>https://github.com/openscore/score-actions</url>
 
     <licenses>
         <license>
@@ -51,9 +51,9 @@
     </developers>
 
     <scm>
-        <connection>scm:git:https://openscore/score-content.git</connection>
-        <developerConnection>scm:git:git@github.com:openscore/score-content.git</developerConnection>
-        <url>https://github.com/openscore/score-content.git</url>
+        <connection>scm:git:https://openscore/score-actions.git</connection>
+        <developerConnection>scm:git:git@github.com:openscore/score-actions.git</developerConnection>
+        <url>https://github.com/openscore/score-actions.git</url>
         <tag>master</tag>
     </scm>
 

--- a/score-utilities/pom.xml
+++ b/score-utilities/pom.xml
@@ -21,9 +21,9 @@
     </properties>
 
     <scm>
-        <connection>scm:git:https://openscore/score-content.git</connection>
-        <developerConnection>scm:git:git@github.com:openscore/score-content.git</developerConnection>
-        <url>https://github.com/openscore/score-content.git</url>
+        <connection>scm:git:https://openscore/score-actions.git</connection>
+        <developerConnection>scm:git:git@github.com:openscore/score-actions.git</developerConnection>
+        <url>https://github.com/openscore/score-actions.git</url>
         <tag>master</tag>
     </scm>
     <distributionManagement>


### PR DESCRIPTION
@hararzafrir , we changed the repository name from score-content to score-actions
Please review the change and merge it to the master if it's OK