### PR TITLE
Changed the error messages for the scenarios: invalid proxy port, url and x509HostVerifier

### DIFF
--- a/score-http-client/src/main/java/org/openscore/content/httpclient/build/RequestConfigBuilder.java
+++ b/score-http-client/src/main/java/org/openscore/content/httpclient/build/RequestConfigBuilder.java
@@ -61,8 +61,8 @@ public class RequestConfigBuilder {
             try {
                 proxy = new HttpHost(proxyHost, Integer.parseInt(proxyPort));
             } catch (NumberFormatException e) {
-                throw new IllegalArgumentException("Cound not parse '"+ HttpClientInputs.PROXY_PORT
-                        +"' input: " + e.getMessage(), e);
+                throw new IllegalArgumentException("Invalid value '" + proxyPort + "' for input '" + HttpClientInputs.PROXY_PORT
+                        + "'. Valid Values: Integer values greater then 0. " , e);
             }
         }
         int connectionTimeout = Integer.parseInt(this.connectionTimeout);

--- a/score-http-client/src/main/java/org/openscore/content/httpclient/build/RequestConfigBuilder.java
+++ b/score-http-client/src/main/java/org/openscore/content/httpclient/build/RequestConfigBuilder.java
@@ -62,7 +62,7 @@ public class RequestConfigBuilder {
                 proxy = new HttpHost(proxyHost, Integer.parseInt(proxyPort));
             } catch (NumberFormatException e) {
                 throw new IllegalArgumentException("Invalid value '" + proxyPort + "' for input '" + HttpClientInputs.PROXY_PORT
-                        + "'. Valid Values: Integer values greater then 0. " , e);
+                        + "'. Valid Values: Integer values greater than 0. " , e);
             }
         }
         int connectionTimeout = Integer.parseInt(this.connectionTimeout);

--- a/score-http-client/src/main/java/org/openscore/content/httpclient/build/URIBuilder.java
+++ b/score-http-client/src/main/java/org/openscore/content/httpclient/build/URIBuilder.java
@@ -44,13 +44,13 @@ public class URIBuilder {
             //validate as URL
             new URL(url);
         } catch (MalformedURLException e) {
-            throw new IllegalArgumentException("could not parse " + url, e);
+            throw new IllegalArgumentException("the value '" + url + "' is not a valid URL", e);
         }
         org.apache.http.client.utils.URIBuilder uriBuilder;
         try {
             uriBuilder = new org.apache.http.client.utils.URIBuilder(url);
         } catch (URISyntaxException e) {
-            throw new IllegalArgumentException("could not parse " + url + " as a URI", e);
+            throw new IllegalArgumentException("the value '" + url + "' is not a valid URI", e);
         }
 
         boolean bEncodeQueryParams = !Boolean.parseBoolean(queryParamsAreURLEncoded);

--- a/score-http-client/src/main/java/org/openscore/content/httpclient/build/conn/SSLConnectionSocketFactoryBuilder.java
+++ b/score-http-client/src/main/java/org/openscore/content/httpclient/build/conn/SSLConnectionSocketFactoryBuilder.java
@@ -38,7 +38,7 @@ public class SSLConnectionSocketFactoryBuilder {
     private String keystorePassword;
     private String trustKeystore;
     private String trustPassword;
-    private String x509HostnameVerifier = "strict";
+    private String x509HostnameVerifierInputValue = "strict";
 
     protected KeyStore createKeyStore(final URL url, final String password)
             throws KeyStoreException, NoSuchAlgorithmException, CertificateException, IOException {
@@ -109,8 +109,8 @@ public class SSLConnectionSocketFactoryBuilder {
 
         SSLConnectionSocketFactory sslsf;
         try {
-            String x509HostnameVerifierStr = x509HostnameVerifier.toLowerCase();
-            X509HostnameVerifier x509HostnameVerifier = null;
+            String x509HostnameVerifierStr = x509HostnameVerifierInputValue.toLowerCase();
+            X509HostnameVerifier x509HostnameVerifier;
             switch (x509HostnameVerifierStr) {
                 case "strict":
                     x509HostnameVerifier = SSLConnectionSocketFactory.STRICT_HOSTNAME_VERIFIER;
@@ -122,11 +122,13 @@ public class SSLConnectionSocketFactoryBuilder {
                     x509HostnameVerifier = SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER;
                     break;
                 default:
-                    x509HostnameVerifier = SSLConnectionSocketFactory.STRICT_HOSTNAME_VERIFIER;
+                    throw new IllegalArgumentException("Invalid value '"+ x509HostnameVerifierInputValue +"' for input 'x509HostnameVerifier'. Valid values: 'strict','browser_compatible','allow_all'.");
             }
-
             sslsf = new SSLConnectionSocketFactory(sslContextBuilder.build(), x509HostnameVerifier);
         } catch (Exception e) {
+            if(e instanceof IllegalArgumentException){
+                throw new IllegalArgumentException(e.getMessage());
+            }
             throw new RuntimeException(e.getMessage() + ". " + SSL_CONNECTION_ERROR, e);
         }
         return sslsf;
@@ -190,7 +192,7 @@ public class SSLConnectionSocketFactoryBuilder {
 
     public SSLConnectionSocketFactoryBuilder setX509HostnameVerifier(String x509HostnameVerifier) {
         if (!StringUtils.isEmpty(x509HostnameVerifier)) {
-            this.x509HostnameVerifier = x509HostnameVerifier;
+            this.x509HostnameVerifierInputValue = x509HostnameVerifier;
         }
         return this;
     }

--- a/score-http-client/src/test/java/org/openscore/content/httpclient/build/RequestConfigBuilderTest.java
+++ b/score-http-client/src/test/java/org/openscore/content/httpclient/build/RequestConfigBuilderTest.java
@@ -20,8 +20,9 @@ import org.apache.http.HttpException;
 import org.apache.http.client.config.RequestConfig;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.openscore.content.httpclient.build.RequestConfigBuilder;
+import org.junit.rules.ExpectedException;
 
 import java.net.URISyntaxException;
 
@@ -35,6 +36,9 @@ import static junit.framework.Assert.*;
 public class RequestConfigBuilderTest {
 
     private RequestConfigBuilder requestConfigBuilder;
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -74,6 +78,18 @@ public class RequestConfigBuilderTest {
         assertEquals("0", String.valueOf(reqConfig.getConnectTimeout()));
         assertEquals("0", String.valueOf(reqConfig.getSocketTimeout()));
         assertNull(reqConfig.getProxy());
+    }
+
+    @Test
+    public void testBuildWithInvalidProxyPort(){
+        final String invalidProxyPort = "invalidProxyPortText";
+        final String expectedExceptionMessage ="Invalid value '"+ invalidProxyPort +"' for input 'proxyPort'. Valid Values: Integer values greater then 0";
+
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage(expectedExceptionMessage);
+        requestConfigBuilder.setProxyHost("myproxy.com")
+                .setProxyPort(invalidProxyPort)
+                .buildRequestConfig();
     }
 }
 

--- a/score-http-client/src/test/java/org/openscore/content/httpclient/build/RequestConfigBuilderTest.java
+++ b/score-http-client/src/test/java/org/openscore/content/httpclient/build/RequestConfigBuilderTest.java
@@ -83,7 +83,7 @@ public class RequestConfigBuilderTest {
     @Test
     public void testBuildWithInvalidProxyPort(){
         final String invalidProxyPort = "invalidProxyPortText";
-        final String expectedExceptionMessage ="Invalid value '"+ invalidProxyPort +"' for input 'proxyPort'. Valid Values: Integer values greater then 0";
+        final String expectedExceptionMessage ="Invalid value '"+ invalidProxyPort +"' for input 'proxyPort'. Valid Values: Integer values greater than 0";
 
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage(expectedExceptionMessage);

--- a/score-http-client/src/test/java/org/openscore/content/httpclient/build/URIBuilderTest.java
+++ b/score-http-client/src/test/java/org/openscore/content/httpclient/build/URIBuilderTest.java
@@ -62,7 +62,7 @@ public class URIBuilderTest {
     public void buildURIWithException() throws UnsupportedEncodingException, URISyntaxException {
         String url = "http://[localhost]:8002";
         exception.expect(IllegalArgumentException.class);
-        exception.expectMessage("could not parse");
+        exception.expectMessage("the value 'http://[localhost]:8002' is not a valid URL");
         new URIBuilder().setUrl(url).setQueryParamsAreURLEncoded("true").setQueryParams("").buildURI();
     }
 }

--- a/score-http-client/src/test/java/org/openscore/content/httpclient/build/conn/SSLConnectionSocketFactoryBuilderTest.java
+++ b/score-http-client/src/test/java/org/openscore/content/httpclient/build/conn/SSLConnectionSocketFactoryBuilderTest.java
@@ -16,7 +16,6 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.openscore.content.httpclient.build.conn.SSLConnectionSocketFactoryBuilder;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -32,9 +31,7 @@ import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.powermock.api.mockito.PowerMockito.doNothing;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.whenNew;
+import static org.powermock.api.mockito.PowerMockito.*;
 
 /**
  * User: Adina Tusa
@@ -201,5 +198,21 @@ public class SSLConnectionSocketFactoryBuilderTest {
         KeyStore keystore = builder.createKeyStore(urlMock, PASSWORD);
         verify(keyStoreMock).load(inputStreamMock, PASSWORD.toCharArray());
         assertEquals(keystore, keyStoreMock);
+    }
+
+    @Test
+    public void testWithInvalidX509HostnameVerifier() throws Exception{
+        final String invalidX509HostNameVerifier = "InvalidX509HosnameVerifier";
+        final String invalidX509HostNameVerifierErrorMessage = "Invalid value '" + invalidX509HostNameVerifier + "' for input 'x509HostnameVerifier'. Valid values: 'strict','browser_compatible','allow_all'";
+
+        builder = new SSLConnectionSocketFactoryBuilder();
+        builder.setTrustAllRoots("true");
+        builder.setX509HostnameVerifier(invalidX509HostNameVerifier);
+        mockStatic(SSLContexts.class);
+        when(SSLContexts.custom()).thenReturn(sslContextBuilderMock);
+
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage(invalidX509HostNameVerifierErrorMessage);
+        builder.build();
     }
 }


### PR DESCRIPTION


Signed-off-by: Bogdan Nane <bogdan.nane@hp.com> : Changed the error
messages for the scenarios: invalid proxy port, invalid
x509HostVerifier, invalid uri. Now throws an exception when an invalid
x509HostVerifier value is provided. Updated tests.