### PR TITLE
ALM26577 - Allow SSL3, TLS1, TSL1.1 and TLS1.2 protocols for HttpClient.

### DIFF
--- a/score-http-client/pom.xml
+++ b/score-http-client/pom.xml
@@ -68,7 +68,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.3.5</version>
+            <version>4.3.6</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpmime</artifactId>
-            <version>4.3.5</version>
+            <version>4.3.6</version>
         </dependency>
         <dependency>
             <groupId>jcifs</groupId>

--- a/score-http-client/src/main/java/org/openscore/content/httpclient/build/conn/SSLConnectionSocketFactoryBuilder.java
+++ b/score-http-client/src/main/java/org/openscore/content/httpclient/build/conn/SSLConnectionSocketFactoryBuilder.java
@@ -125,7 +125,8 @@ public class SSLConnectionSocketFactoryBuilder {
                     x509HostnameVerifier = SSLConnectionSocketFactory.STRICT_HOSTNAME_VERIFIER;
             }
 
-            sslsf = new SSLConnectionSocketFactory(sslContextBuilder.build(), x509HostnameVerifier);
+            // Allow SSLv3, TLSv1, TLSv1.1 and TLSv1.2 protocols only. Client-server communication starts with TLSv1.2 and fallbacks to SSLv3 if needed.
+            sslsf = new SSLConnectionSocketFactory(sslContextBuilder.build(), new String[] {"SSLv3", "TLSv1", "TLSv1.1", "TLSv1.2"}, null, x509HostnameVerifier);
         } catch (Exception e) {
             throw new RuntimeException(e.getMessage() + ". " + SSL_CONNECTION_ERROR, e);
         }

--- a/score-http-client/src/test/java/org/openscore/content/httpclient/build/conn/SSLConnectionSocketFactoryBuilderTest.java
+++ b/score-http-client/src/test/java/org/openscore/content/httpclient/build/conn/SSLConnectionSocketFactoryBuilderTest.java
@@ -30,6 +30,7 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.isA;
+import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.doNothing;
@@ -88,14 +89,18 @@ public class SSLConnectionSocketFactoryBuilderTest {
         when(sslContextBuilderMock.useTLS()).thenReturn(null);
         when(sslContextBuilderMock.build()).thenReturn(sslCtxMock);
 
-        whenNew(SSLConnectionSocketFactory.class)
-                .withParameterTypes(SSLContext.class, X509HostnameVerifier.class)
-                .withArguments(isA(SSLContext.class), isA(X509HostnameVerifier.class))
-                .thenReturn(sslsfMock);
+        prepareSSLConnectionSocketFactory();
 
         SSLConnectionSocketFactory sslsf = builder.build();
         assertNotNull(sslsf);
         assertEquals(sslsfMock, sslsf);
+    }
+
+    private void prepareSSLConnectionSocketFactory() throws Exception {
+        whenNew(SSLConnectionSocketFactory.class)
+                .withParameterTypes(SSLContext.class, String[].class, String[].class, X509HostnameVerifier.class)
+                .withArguments(isA(SSLContext.class), isA(String[].class), isNull(), isA(X509HostnameVerifier.class))
+                .thenReturn(sslsfMock);
     }
 
     @Test
@@ -112,10 +117,7 @@ public class SSLConnectionSocketFactoryBuilderTest {
 
         when(sslContextBuilderMock.build()).thenReturn(sslCtxMock);
 
-        whenNew(SSLConnectionSocketFactory.class)
-                .withParameterTypes(SSLContext.class, X509HostnameVerifier.class)
-                .withArguments(isA(SSLContext.class), isA(X509HostnameVerifier.class))
-                .thenReturn(sslsfMock);
+        prepareSSLConnectionSocketFactory();
 
         SSLConnectionSocketFactory sslsf = builder.build();
         assertNotNull(sslsf);


### PR DESCRIPTION
HTTP Client operations as they are, do not work with TLS 1.1 and TLS 1.2. SSL3 is also required in case clients have their environment configured with SSL3. With this version of the code, operations will work with SSL3, TLS1.0, TLS1.1 and TLS1.2. 
Signed-off-by: George Giloan giloan@hp.com
