### PR TITLE
Fixed issue: Proxy port validation

### DIFF
--- a/score-http-client/src/main/java/org/openscore/content/httpclient/HttpClientAction.java
+++ b/score-http-client/src/main/java/org/openscore/content/httpclient/HttpClientAction.java
@@ -68,7 +68,9 @@ public class HttpClientAction {
      *                              Format: http://docs.oracle.com/javase/7/docs/jre/api/security/jaas/spec/com/sun/security/auth/module/Krb5LoginModule.html
      * @param kerberosSkipPortForLookup Do not include port in the key distribution center database lookup. Default value: true. Valid values: true, false
      * @param proxyHost The proxy server used to access the web site.
-     * @param proxyPort The proxy server port. Default value: 8080.
+     * @param proxyPort The proxy server port. Default value: 8080. Valid values: -1 and integer values greater than 0.
+     *                  The value '-1' indicates that the proxy port is not set and the scheme default port will be used.
+     *                  If the scheme is 'http://' and the 'proxyPort' is set to '-1' then port '80' will be used.
      * @param proxyUsername The user name used when connecting to the proxy. The 'authType' input will be used to choose authentication type.
      *                      The 'Basic' and 'Digest' proxy authentication types are supported.
      * @param proxyPassword The proxy server password associated with the proxyUsername input value.

--- a/score-http-client/src/main/java/org/openscore/content/httpclient/build/RequestConfigBuilder.java
+++ b/score-http-client/src/main/java/org/openscore/content/httpclient/build/RequestConfigBuilder.java
@@ -13,7 +13,6 @@ package org.openscore.content.httpclient.build;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHost;
 import org.apache.http.client.config.RequestConfig;
-import org.openscore.content.httpclient.HttpClientInputs;
 
 public class RequestConfigBuilder {
     private String connectionTimeout = "0";
@@ -57,13 +56,10 @@ public class RequestConfigBuilder {
 
     public RequestConfig buildRequestConfig() {
         HttpHost proxy = null;
+        final int proxyPortNumber;
         if (proxyHost != null && !proxyHost.isEmpty()) {
-            try {
-                proxy = new HttpHost(proxyHost, Integer.parseInt(proxyPort));
-            } catch (NumberFormatException e) {
-                throw new IllegalArgumentException("Invalid value '" + proxyPort + "' for input '" + HttpClientInputs.PROXY_PORT
-                        + "'. Valid Values: Integer values greater than 0. " , e);
-            }
+            proxyPortNumber = Utils.validatePortNumber(proxyPort);
+            proxy = new HttpHost(proxyHost, proxyPortNumber);
         }
         int connectionTimeout = Integer.parseInt(this.connectionTimeout);
         int socketTimeout = Integer.parseInt(this.socketTimeout);

--- a/score-http-client/src/main/java/org/openscore/content/httpclient/build/Utils.java
+++ b/score-http-client/src/main/java/org/openscore/content/httpclient/build/Utils.java
@@ -12,6 +12,7 @@ package org.openscore.content.httpclient.build;
 
 import org.apache.http.NameValuePair;
 import org.apache.http.message.BasicNameValuePair;
+import org.openscore.content.httpclient.HttpClientInputs;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -69,4 +70,26 @@ public class Utils {
         return encodedParams;
     }
 
+    /**
+     * Checks if a given value represents a valid port number and returns an int value representing that port number otherwise throws an exception when an invalid port value is provided.
+     * @param portStringValue String value representing the port number;
+     * @return int value representing a valid port number
+     */
+    public static int validatePortNumber(String portStringValue){
+        final int portNumber;
+        final StringBuilder exceptionMessageBuilder = new StringBuilder();
+        exceptionMessageBuilder.append("Invalid value '").append(portStringValue)
+                .append("' for input '").append( HttpClientInputs.PROXY_PORT)
+                .append("'. Valid Values: Integer values greater than 0. ");
+
+        try{
+            portNumber = Integer.parseInt(portStringValue);
+             if((portNumber < 0) && (portNumber != -1)){
+                    throw new IllegalArgumentException(exceptionMessageBuilder.toString());
+                }
+        } catch (NumberFormatException e) {
+             throw new IllegalArgumentException(exceptionMessageBuilder.toString() , e);
+        }
+        return portNumber;
+    }
 }

--- a/score-http-client/src/main/java/org/openscore/content/httpclient/build/Utils.java
+++ b/score-http-client/src/main/java/org/openscore/content/httpclient/build/Utils.java
@@ -83,7 +83,7 @@ public class Utils {
         final StringBuilder exceptionMessageBuilder = new StringBuilder();
         exceptionMessageBuilder.append("Invalid value '").append(portStringValue)
                 .append("' for input '").append( HttpClientInputs.PROXY_PORT)
-                .append("'. Valid Values: -1, integer values greater than 0. ");
+                .append("'. Valid Values: -1 and integer values greater than 0. ");
 
         try{
             portNumber = Integer.parseInt(portStringValue);

--- a/score-http-client/src/main/java/org/openscore/content/httpclient/build/Utils.java
+++ b/score-http-client/src/main/java/org/openscore/content/httpclient/build/Utils.java
@@ -72,6 +72,9 @@ public class Utils {
 
     /**
      * Checks if a given value represents a valid port number and returns an int value representing that port number otherwise throws an exception when an invalid port value is provided.
+     * Valid port values: -1 and integer numbers greater than 0.
+     * Although network specifications state that port values need to be 16-bit unsigned integers, the value '-1' is considered valid by some party components.
+     * Example: For the Apache HttpHost class, which is used in {@link org.openscore.content.httpclient.build.RequestConfigBuilder#buildRequestConfig()} , the value '-1' indicates the scheme default port.
      * @param portStringValue String value representing the port number;
      * @return int value representing a valid port number
      */
@@ -80,7 +83,7 @@ public class Utils {
         final StringBuilder exceptionMessageBuilder = new StringBuilder();
         exceptionMessageBuilder.append("Invalid value '").append(portStringValue)
                 .append("' for input '").append( HttpClientInputs.PROXY_PORT)
-                .append("'. Valid Values: Integer values greater than 0. ");
+                .append("'. Valid Values: -1, integer values greater than 0. ");
 
         try{
             portNumber = Integer.parseInt(portStringValue);

--- a/score-http-client/src/main/java/org/openscore/content/httpclient/build/auth/CredentialsProviderBuilder.java
+++ b/score-http-client/src/main/java/org/openscore/content/httpclient/build/auth/CredentialsProviderBuilder.java
@@ -17,6 +17,7 @@ import org.apache.http.auth.NTCredentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
 import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.openscore.content.httpclient.build.Utils;
 
 import java.security.Principal;
 import java.util.Locale;
@@ -106,7 +107,7 @@ public class CredentialsProviderBuilder {
         if (!StringUtils.isEmpty(proxyUsername)) {
             int intProxyPort = 8080;
             if (!StringUtils.isEmpty(proxyPort)) {
-                intProxyPort = Integer.parseInt(proxyPort);
+                intProxyPort = Utils.validatePortNumber(proxyPort);
             }
             credentialsProvider.setCredentials(new AuthScope(proxyHost, intProxyPort),
                     new UsernamePasswordCredentials(proxyUsername, proxyPassword));

--- a/score-http-client/src/test/java/org/openscore/content/httpclient/build/RequestConfigBuilderTest.java
+++ b/score-http-client/src/test/java/org/openscore/content/httpclient/build/RequestConfigBuilderTest.java
@@ -83,13 +83,47 @@ public class RequestConfigBuilderTest {
     @Test
     public void testBuildWithInvalidProxyPort(){
         final String invalidProxyPort = "invalidProxyPortText";
-        final String expectedExceptionMessage ="Invalid value '"+ invalidProxyPort +"' for input 'proxyPort'. Valid Values: Integer values greater than 0";
+        final String expectedExceptionMessage = "Invalid value '"+ invalidProxyPort +"' for input 'proxyPort'. Valid Values: Integer values greater than 0";
 
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage(expectedExceptionMessage);
         requestConfigBuilder.setProxyHost("myproxy.com")
                 .setProxyPort(invalidProxyPort)
                 .buildRequestConfig();
+    }
+
+    /*
+       According to network specifications: a port number should be a 16-bit unsigned integer.
+       Therefor negative values are not considered valid and should not be allowed.
+     */
+    @Test
+    public void testBuildWithNegativeProxyPort(){
+        final String invalidProxyPort = "-2";
+        final String expectedExceptionMessage = "Invalid value '"+ invalidProxyPort +"' for input 'proxyPort'. Valid Values: Integer values greater than 0";
+
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage(expectedExceptionMessage);
+        requestConfigBuilder.setProxyHost("myproxy.com")
+                .setProxyPort(invalidProxyPort)
+                .buildRequestConfig();
+    }
+
+    /*
+       Tests if a request configuration is created when the value '-1' is provided as a proxy port.
+       The the value '-1' is provided then the proxy port input will be ignored and the default port of the scheme will be used.
+       For example the port 80 will be used if the scheme is http.
+     */
+    @Test
+    public void testBuildWithAcceptedNegativeProxyPort(){
+        final String validProxyPort = "-1";
+
+        RequestConfig reqConfig = requestConfigBuilder
+                .setProxyHost("myproxy.com")
+                .setProxyPort(validProxyPort)
+                .buildRequestConfig();
+        assertNotNull(reqConfig);
+        assertNotNull(reqConfig.getProxy());
+        assertEquals("myproxy.com", reqConfig.getProxy().getHostName());
     }
 }
 

--- a/score-http-client/src/test/java/org/openscore/content/httpclient/build/RequestConfigBuilderTest.java
+++ b/score-http-client/src/test/java/org/openscore/content/httpclient/build/RequestConfigBuilderTest.java
@@ -83,7 +83,7 @@ public class RequestConfigBuilderTest {
     @Test
     public void testBuildWithInvalidProxyPort(){
         final String invalidProxyPort = "invalidProxyPortText";
-        final String expectedExceptionMessage = "Invalid value '"+ invalidProxyPort +"' for input 'proxyPort'. Valid Values: Integer values greater than 0";
+        final String expectedExceptionMessage = "Invalid value '"+ invalidProxyPort +"' for input 'proxyPort'. Valid Values: -1 and integer values greater than 0";
 
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage(expectedExceptionMessage);
@@ -99,7 +99,7 @@ public class RequestConfigBuilderTest {
     @Test
     public void testBuildWithNegativeProxyPort(){
         final String invalidProxyPort = "-2";
-        final String expectedExceptionMessage = "Invalid value '"+ invalidProxyPort +"' for input 'proxyPort'. Valid Values: Integer values greater than 0";
+        final String expectedExceptionMessage = "Invalid value '"+ invalidProxyPort +"' for input 'proxyPort'. Valid Values: -1 and integer values greater than 0";
 
         exception.expect(IllegalArgumentException.class);
         exception.expectMessage(expectedExceptionMessage);

--- a/score-http-client/src/test/java/org/openscore/content/httpclient/build/auth/CredentialsProviderBuilderTest.java
+++ b/score-http-client/src/test/java/org/openscore/content/httpclient/build/auth/CredentialsProviderBuilderTest.java
@@ -71,7 +71,7 @@ public class CredentialsProviderBuilderTest {
     @Test
     public void createCredentialProviderWithInvalidProxyPort(){
         final String invalidProxyPort = "invalidProxyPort";
-        final String expectedExceptionMessage = "Invalid value '"+ invalidProxyPort +"' for input 'proxyPort'. Valid Values: Integer values greater than 0";
+        final String expectedExceptionMessage = "Invalid value '"+ invalidProxyPort +"' for input 'proxyPort'. Valid Values: -1 and integer values greater than 0";
         final AuthTypes authTypes = new AuthTypes("");
 
         CredentialsProviderBuilder builder = new CredentialsProviderBuilder()
@@ -87,7 +87,7 @@ public class CredentialsProviderBuilderTest {
     @Test
     public void createCredentialProviderWithNegativeProxyPort(){
         final String invalidProxyPort = "-2";
-        final String expectedExceptionMessage = "Invalid value '"+ invalidProxyPort +"' for input 'proxyPort'. Valid Values: Integer values greater than 0";
+        final String expectedExceptionMessage = "Invalid value '"+ invalidProxyPort +"' for input 'proxyPort'. Valid Values: -1 and integer values greater than 0";
         final AuthTypes authTypes = new AuthTypes("");
 
         CredentialsProviderBuilder builder = new CredentialsProviderBuilder()

--- a/score-http-client/src/test/java/org/openscore/content/httpclient/build/auth/CredentialsProviderBuilderTest.java
+++ b/score-http-client/src/test/java/org/openscore/content/httpclient/build/auth/CredentialsProviderBuilderTest.java
@@ -10,15 +10,15 @@
 
 package org.openscore.content.httpclient.build.auth;
 
-import org.apache.http.client.config.AuthSchemes;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
 import org.apache.http.auth.NTCredentials;
 import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.config.AuthSchemes;
+import org.junit.Rule;
 import org.junit.Test;
-import org.openscore.content.httpclient.build.auth.AuthTypes;
-import org.openscore.content.httpclient.build.auth.CredentialsProviderBuilder;
+import org.junit.rules.ExpectedException;
 
 import static junit.framework.Assert.assertEquals;
 import static org.hamcrest.CoreMatchers.instanceOf;
@@ -30,6 +30,9 @@ import static org.junit.Assert.assertThat;
  * Date: 7/2/14
  */
 public class CredentialsProviderBuilderTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
 
     @Test
     public void createNtlmCredentialsProvider() {
@@ -63,6 +66,38 @@ public class CredentialsProviderBuilderTest {
         assertThat(credentials, instanceOf(UsernamePasswordCredentials.class));
         UsernamePasswordCredentials userCredentials = (UsernamePasswordCredentials) credentials;
         assertEquals("pass", userCredentials.getPassword());
+    }
+
+    @Test
+    public void createCredentialProviderWithInvalidProxyPort(){
+        final String invalidProxyPort = "invalidProxyPort";
+        final String expectedExceptionMessage = "Invalid value '"+ invalidProxyPort +"' for input 'proxyPort'. Valid Values: Integer values greater than 0";
+        final AuthTypes authTypes = new AuthTypes("");
+
+        CredentialsProviderBuilder builder = new CredentialsProviderBuilder()
+                .setAuthTypes(authTypes)
+                .setProxyPort(invalidProxyPort)
+                .setProxyUsername("proxyUsername");
+
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage(expectedExceptionMessage);
+        builder.buildCredentialsProvider();
+    }
+
+    @Test
+    public void createCredentialProviderWithNegativeProxyPort(){
+        final String invalidProxyPort = "-2";
+        final String expectedExceptionMessage = "Invalid value '"+ invalidProxyPort +"' for input 'proxyPort'. Valid Values: Integer values greater than 0";
+        final AuthTypes authTypes = new AuthTypes("");
+
+        CredentialsProviderBuilder builder = new CredentialsProviderBuilder()
+                .setAuthTypes(authTypes)
+                .setProxyPort(invalidProxyPort)
+                .setProxyUsername("proxyUsername");
+
+        exception.expect(IllegalArgumentException.class);
+        exception.expectMessage(expectedExceptionMessage);
+        builder.buildCredentialsProvider();
     }
 
     private CredentialsProvider getCredentialsProvider(String authType) {


### PR DESCRIPTION
Signed-off-by: Bogdan Nane <bogdan.nane@hp.com>: Moved the port
validation into a utility class and used the resulting method to
validate the proxy port in both RequestConfigBuilder and
CredentialsProviderBuilder.