### PR TITLE
Adding Javadoc and sources jars for score-ssh

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,22 @@
             <artifactId>maven-javadoc-plugin</artifactId>
             <version>2.8</version>
           </plugin>
+          <plugin>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>2.2.1</version>
+              <executions>
+                <execution>
+                  <id>attach-sources</id>
+                  <phase>verify</phase>
+                  <goals>
+                    <goal>jar-no-fork</goal>
+                  </goals>
+                </execution>
+              </executions>
+              <configuration>
+                <attach>true</attach>
+              </configuration>
+            </plugin>
         </plugins>
       </pluginManagement>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,11 @@
             </plugin>
         </plugins>
       </pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-source-plugin</artifactId>
+        </plugin>
+      </plugins>
     </build>
     <distributionManagement>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,16 @@
         <organizationUrl>http://www8.hp.com/us/en/software/enterprise-software.html</organizationUrl>
       </developer>
     </developers>
+    <build>
+      <pluginManagement>
+        <plugins>
+          <plugin>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.8</version>
+          </plugin>
+        </plugins>
+      </pluginManagement>
+    </build>
     <distributionManagement>
         <repository>
             <id>ossrh</id>
@@ -131,7 +141,7 @@
       </profile>
     </profiles>
 	<modules>
-		<module>score-http-client</module>
+	<module>score-http-client</module>
         <module>score-ssh</module>
         <module>score-mail</module>
         <module>score-json</module>

--- a/score-ssh/pom.xml
+++ b/score-ssh/pom.xml
@@ -115,16 +115,43 @@
         <!-- end of testing dependencies -->
     </dependencies>
     <build>
+      <pluginManagement>
         <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
+          <plugin>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <version>2.8</version>
+          </plugin>
+          <plugin>
+            <artifactId>maven-source-plugin</artifactId>
+            <version>2.2.1</version>
+              <executions>
+                <execution>
+                  <id>attach-sources</id>
+                  <phase>verify</phase>
+                  <goals>
+                    <goal>jar-no-fork</goal>
+                  </goals>
+                </execution>
+              </executions>
+              <configuration>
+                <attach>true</attach>
+              </configuration>
             </plugin>
         </plugins>
+      </pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-source-plugin</artifactId>
+        </plugin>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.1</version>
+          <configuration>
+            <source>1.7</source>
+            <target>1.7</target>
+          </configuration>
+        </plugin>
+      </plugins>
     </build>
     <profiles>
       <profile>


### PR DESCRIPTION
Maven Central requires that Javadocs and Sources jars are present in each and every release